### PR TITLE
Replaced source_wads attribute with method

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -285,31 +285,6 @@ calculate_wads <- function(tube_rel_abundance) {
 
 
 
-#' Calculate global weighted average density (WAD) value for a source_mat_id (internal)
-#'
-#' @param sample_data (*qsip_sample_data*) Sample data object
-#'
-#' @returns A dataframe with two columns, 1) the source_mat_id and 2) the global
-#' WAD value for that source_mat_id
-#'
-#' @keywords internal
-
-calculate_source_wads <- function(sample_data) {
-
-  stopifnot("sample_data should be of class <qsip_sample_data>" = inherits(sample_data, qsip_sample_data))
-
-  # bind variables
-  source_mat_id <- gradient_pos_density <- gradient_pos_rel_amt <- NULL
-
-  sample_data@data |>
-    dplyr::group_by(source_mat_id) |>
-    dplyr::summarize(
-      WAD = weighted.mean(gradient_pos_density, gradient_pos_rel_amt),
-      .groups = "drop"
-    )
-}
-
-
 #' Returns the max labeling of a given isotope (internal)
 #'
 #' @param isotope The heavy isotope (13C, 15N or 18O)

--- a/R/plot.R
+++ b/R/plot.R
@@ -170,7 +170,7 @@ plot_sample_curves <- function(qsip_data_object,
     dplyr::filter(gradient_position > 0) |>
     dplyr::summarize(tube_rel_abundance = sum(tube_rel_abundance), .by = c(sample_id, source_mat_id, gradient_position, gradient_pos_density, isotope))
 
-  source_wads <- qsip_data_object@source_wads |>
+  source_wads <- source_wads(qsip_data_object) |>
     dplyr::filter(!is.na(WAD)) |>
     dplyr::left_join(qsip_data_object@source_data@data, by = "source_mat_id")
 
@@ -259,7 +259,7 @@ plot_source_wads <- function(qsip_data,
     stop("group must be a column name in source_data", call. = FALSE)
   }
 
-  p <- qsip_data@source_wads |>
+  p <- source_wads(qsip_data) |>
     dplyr::filter(!is.na(WAD)) |> # filter unfractionated
     dplyr::left_join(source_data@data, by = "source_mat_id") |>
     ggplot2::ggplot(ggplot2::aes(color = isotope)) +

--- a/R/run.R
+++ b/R/run.R
@@ -239,9 +239,6 @@ run_feature_filter <- function(qsip_data_object,
     dplyr::filter(source_mat_id %in% c(qsip_data_object@filter_results$labeled_source_mat_ids, qsip_data_object@filter_results$unlabeled_source_mat_ids)) |>
     dplyr::filter(feature_id %in% qsip_data_object@filter_results$retained_features)
 
-  qsip_data_object@source_wads = qsip_data_object@source_wads |>
-    dplyr::filter(source_mat_id %in% c(qsip_data_object@filter_results$labeled_source_mat_ids, qsip_data_object@filter_results$unlabeled_source_mat_ids))
-
   qsip_data_object@fraction_counts = qsip_data_object@fraction_counts |>
     dplyr::filter(source_mat_id %in% c(qsip_data_object@filter_results$labeled_source_mat_ids, qsip_data_object@filter_results$unlabeled_source_mat_ids)) |>
     dplyr::filter(feature_id %in% qsip_data_object@filter_results$retained_features)

--- a/tests/testthat/_snaps/calculate_source_wads.md
+++ b/tests/testthat/_snaps/calculate_source_wads.md
@@ -1,7 +1,7 @@
 # works correctly
 
     Code
-      calculate_source_wads(example_sample_object)
+      source_wads(example_qsip_object)
     Output
       # A tibble: 15 x 2
          source_mat_id   WAD

--- a/tests/testthat/test-calculate_source_wads.R
+++ b/tests/testthat/test-calculate_source_wads.R
@@ -1,8 +1,3 @@
 test_that("works correctly", {
-  expect_snapshot(calculate_source_wads(example_sample_object))
-})
-
-test_that("wrong input type fails", {
-  expect_error(calculate_source_wads(example_source_object),
-               "sample_data should be of class <qsip_sample_data>")
+  expect_snapshot(source_wads(example_qsip_object))
 })

--- a/tests/testthat/test-calculate_wads.R
+++ b/tests/testthat/test-calculate_wads.R
@@ -4,7 +4,7 @@ test_that("dimensions of returned data are correct", {
   expect_equal(dim(calculate_wads(example_qsip_object@tube_rel_abundance)$wads), c(9282, 4))
   expect_equal(dim(calculate_wads(example_qsip_object@tube_rel_abundance)$fraction), c(30450, 3))
 
-  expect_equal(dim(calculate_source_wads(example_qsip_object@sample_data)), c(15, 2))
+  expect_equal(dim(source_wads(example_qsip_object)), c(15, 2))
 })
 
 


### PR DESCRIPTION
Removed source_wads from the qsip_data class as an attribute (implemented instead as a method on qsip_data class). This is aimed at exploring feasibility of refactoring we discussed for qiime2. Note that the post-filtered source_wads isn't tested here (nor was it tested previously). Can create that new test if needed.